### PR TITLE
Add is_empty function to check whether there are any remaining packets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,11 @@ where
         }
     }
 
+    /// Returns true if there are no packets in the jitter buffer
+    pub fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
     /// Drops all packets in the jitter buffer
     pub fn clear(&mut self) {
         self.last = None;


### PR DESCRIPTION
Adding this function allows us to check if `pop` returns `None` because there are no more packets, or if there are missing packets.

In our use case we want to wait up to `N` milliseconds before skipping to the newest packet. Currently this means something like:

```rust
if timer_expired {
  let packet = loop {
      match jb.pop() {
         Some(p) => break p;
         None if jb.is_empty() => return Poll::Pending;
         None => continue
      }
  }
}
```